### PR TITLE
fix "same tx different blockhash" issue

### DIFF
--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -220,15 +220,13 @@ function SetupForPool(logger, poolOptions, setupFinished){
                             logger.error(logSystem, logComponent,
                                     'Error with requesting transaction from block daemon: ' + JSON.stringify(tx));
                         }
-                        else{
-                            if (round.blockhash === tx.result.blockhash) {
-                                round.category = tx.result.details[0].category;
-                                if (round.category === 'generate')
-                                    round.amount = tx.result.amount;
-                            } else{
-                                //same txid but different blockhash - orphan?
-                                round.category = 'orphan';
-                            }
+                        else if (round.blockhash !== tx.result.blockhash) {
+                            //same txid but different blockhash - this block is drop-kicked orphan
+                            round.category = 'dropkicked';
+                        } else{
+                            round.category = tx.result.details[0].category;
+                            if (round.category === 'generate')
+                                round.amount = tx.result.amount;
                         }
                     });
 


### PR DESCRIPTION
Hi there!

I've been testing payouts recently in testnet to make sure there is nothing left to fix and suddenly I've got this situation. (below are two members of _blocksPending)

"15f0b6089e5dc6adf21e857f4a9ed187c850c007460b2fabf0ada39786e87c93:9bc303e009c404a0ca0c918934fd517f6e74d5904331379e08520b2b7c3ee8cf:240550:5000400000"
"860636baf63d38469950af865d050d437ff8d8c1d0a189b8b60e6e4470e9fb44:9bc303e009c404a0ca0c918934fd517f6e74d5904331379e08520b2b7c3ee8cf:240550:5000400000"

As you can see I've got same txid but different blockhash ('solution') for the same block height. And BOTH of them was counted as 'generate' because 'gettransaction' actually worked fine for them so no error was generated and this cause payments to be greater than they should be. Luckily there was overspending so I had time to notice this.

Daemon 'listtransaction' command showed me that one of recent blocks was actually orphaned but it has even another txid. Do you have any idea is it something wrong or not?

Anyway, I made a quick fix, please take a look.

btw, I also renamed 'txHash' to 'txid' and 'solution' to 'blockhash' to match daemon terminology better.
