### PR TITLE
Ensure configuration value for validation of pool workers is honored

### DIFF
--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -87,10 +87,14 @@ module.exports = function(logger){
             var shareProcessor = new ShareProcessor(logger, poolOptions)
 
             handlers.auth = function(workerName, password, authCallback){
-                pool.daemon.cmd('validateaddress', [workerName], function(results){
-                    var isValid = results.filter(function(r){return r.response.isvalid}).length > 0;
-                    authCallback(isValid);
-                });
+                if (shareProcessing.internal.validateWorkerAddress !== true)
+                    authCallback(true);
+                else {
+                    pool.daemon.cmd('validateaddress', [workerName], function(results){
+                        var isValid = results.filter(function(r){return r.response.isvalid}).length > 0;
+                        authCallback(isValid);
+                    });
+                }
             };
 
             handlers.share = function(isValidShare, isValidBlock, data){


### PR DESCRIPTION
Fixes the bug where if you disabled worker authorization for pools, workers were authorized anyway.
