### PR TITLE
Update blocknotify.c

### DIFF
--- a/scripts/blocknotify.c
+++ b/scripts/blocknotify.c
@@ -23,7 +23,7 @@ Build with:
 
 
 Usage in daemon coin.conf
-    blocknotify="/bin/blocknotify 127.0.01:8117 mySuperSecurePassword dogecoin %s"
+    blocknotify="/bin/blocknotify 127.0.0.1:8117 mySuperSecurePassword dogecoin %s"
 
 *NOTE* If you use "localhost" as hostname you may get a "13" error (socket / connect / send may consider "localhost" as a broadcast address)
 


### PR DESCRIPTION
Changed sendto to send using TCP so we can control if the block notify produces a connection error.
Added a note about "localhost" usage an possible error 13.
