### PR TITLE
CLI by default listen 127.0.0.1. Wrong point coin deamon not always loca...

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Explanation for each field:
 
 
     /* The NOMP CLI (command-line interface) will listen for commands on this port. For example,
-       blocknotify messages are sent to NOMP through this. */
+       blocknotify messages are sent to NOMP through this. By default listen 0.0.0.0 */
     "cliPort": 17117,
 
     /* By default 'forks' is set to "auto" which will spawn one process/fork/worker for each CPU

--- a/libs/cliListener.js
+++ b/libs/cliListener.js
@@ -32,7 +32,7 @@ var listener = module.exports = function listener(port){
                 emitLog('CLI listener failed to parse message ' + data);
             }
 
-        }).listen(port, '127.0.0.1', function() {
+        }).listen(port, '0.0.0.0', function() {
             emitLog('CLI listening on port ' + port)
         });
     }


### PR DESCRIPTION
CLI by default listen 127.0.0.1. 
Wrong point, coin demon not always located on same host, should be 0.0.0.0 or specified from config
