### PR TITLE
Add confirmed balance for address/worker API call

### DIFF
--- a/libs/api.js
+++ b/libs/api.js
@@ -34,7 +34,7 @@ module.exports = function(logger, portalConfig, poolConfigs){
                 });
 
                 return;
-            case 'balances':
+            case 'balance':
 		var coin=require('url').parse(req.url, true).query.coin;
 		var address=require('url').parse(req.url, true).query.address;
 		var callback=null;


### PR DESCRIPTION
This is hopefully a good starting point for a simple API function that allows a worker to check their confirmed balance. This might have performance problems, since it opens a new redis connection each call, but I'm not good enough at node to really know of a good way around it. 

The intention is to add an unconfirmed balance field as well, but this is a good start. 

Usage: `/api/balance?coin=Testcoin&address=qC7i5QD1FRjJgjyMesU6eSFbakcgAvfFCQ`

returns:

```
{"confirmed": 1234}
```
