### PR TITLE
Allow disable log colors

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -1,5 +1,6 @@
 {
     "logLevel": "debug",
+    "logColors": true,
 
     "cliPort": 17117,
 

--- a/init.js
+++ b/init.js
@@ -26,7 +26,8 @@ var poolConfigs;
 
 
 var logger = new PoolLogger({
-    logLevel: portalConfig.logLevel
+    logLevel: portalConfig.logLevel,
+    logColors: portalConfig.logColors
 });
 
 

--- a/libs/logUtil.js
+++ b/libs/logUtil.js
@@ -30,6 +30,7 @@ var PoolLogger = function (configuration) {
 
 
     var logLevelInt = severityValues[configuration.logLevel];
+    var logColors = configuration.logColors;
 
 
 
@@ -45,16 +46,28 @@ var PoolLogger = function (configuration) {
         }
 
         var entryDesc = dateFormat(new Date(), 'yyyy-mm-dd HH:MM:ss') + ' [' + system + ']\t';
-        entryDesc = severityToColor(severity, entryDesc);
+        if (logColors) {
+            entryDesc = severityToColor(severity, entryDesc);
 
-        var logString =
-                entryDesc +
-                ('[' + component + '] ').italic;
+            var logString =
+                    entryDesc +
+                    ('[' + component + '] ').italic;
 
-        if (subcat)
-            logString += ('(' + subcat + ') ').bold.grey
+            if (subcat)
+                logString += ('(' + subcat + ') ').bold.grey;
 
-        logString += text.grey;
+            logString += text.grey;
+        }
+        else {
+            var logString =
+                    entryDesc +
+                    '[' + component + '] ';
+
+            if (subcat)
+                logString += '(' + subcat + ') ';
+
+            logString += text;
+        }
 
         console.log(logString);
 


### PR DESCRIPTION
If you run this on a console, the logs have nice colors.
But if someone redirect the output to a file, there are lots of stupid characters.

This patch allow disable the colored outputs.
