### PR TITLE
Bind website listener to host

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -11,6 +11,7 @@
 
     "website": {
         "enabled": true,
+        "host": "0.0.0.0",
         "port": 80,
         "stratumHost": "cryppit.com",
         "stats": {

--- a/libs/website.js
+++ b/libs/website.js
@@ -275,12 +275,12 @@ module.exports = function(logger){
     });
 
     try {
-        app.listen(portalConfig.website.port, function () {
-            logger.debug(logSystem, 'Server', 'Website started on port ' + portalConfig.website.port);
+        app.listen(portalConfig.website.port, portalConfig.website.host, function () {
+            logger.debug(logSystem, 'Server', 'Website started on ' + portalConfig.website.host + ':' + portalConfig.website.port);
         });
     }
     catch(e){
-        logger.error(logSystem, 'Server', 'Could not start website on port ' + portalConfig.website.port
+        logger.error(logSystem, 'Server', 'Could not start website on ' + portalConfig.website.host + ':' + portalConfig.website.port
             +  ' - its either in use or you do not have permission');
     }
 


### PR DESCRIPTION
If the internal webserver is behind a nginx/lighttpd/whatever proxy this patch allow to bind the website listener to host (eg 127.0.0.1). Or if the server has multiple interface/ip, allow bind to one ip address.
