### PR TITLE
Fix for x11 switch difficulty incorrect

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -88,7 +88,14 @@
             "algorithm": "x11",
             "ports": {
                 "5555": {
-                    "diff": 0.001
+                    "diff": 0.001,
+                    "varDiff": {
+                        "minDiff": 0.001,
+                        "maxDiff": 1, 
+                        "targetTime": 15, 
+                        "retargetTime": 60, 
+                        "variancePercent": 30 
+                    }
                 }
             }
         }

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -202,6 +202,8 @@ module.exports = function(logger){
             logger[severity](logSystem, logComponent, logSubCat, text);
         }).on('banIP', function(ip, worker){
             process.send({type: 'banIP', ip: ip});
+        }).on('started', function(){
+            _this.setDifficultyForProxyPort(pool, poolOptions.coin.name, poolOptions.coin.algorithm);
         });
 
         pool.start();
@@ -259,17 +261,6 @@ module.exports = function(logger){
                 };
 
 
-                Object.keys(pools).forEach(function (coinName) {
-                    var p = pools[coinName];
-                    if (poolConfigs[coinName].coin.algorithm === algorithm) {
-                        for (var port in portalConfig.switching[switchName].ports) {
-                            if (portalConfig.switching[switchName].ports[port].varDiff)
-                                p.setVarDiff(port, portalConfig.switching[switchName].ports[port].varDiff);
-                        }
-                    }
-                });
-
-
                 Object.keys(proxySwitch[switchName].ports).forEach(function(port){
                     var f = net.createServer(function(socket) {
                         var currentPool = proxySwitch[switchName].currentPool;
@@ -278,8 +269,11 @@ module.exports = function(logger){
                             + switchName + ' from '
                             + socket.remoteAddress + ' on '
                             + port + ' routing to ' + currentPool);
-
-                        pools[currentPool].getStratumServer().handleNewClient(socket);
+                        
+                        if (pools[currentPool])
+                            pools[currentPool].getStratumServer().handleNewClient(socket);
+                        else
+                            pools[initialPool].getStratumServer().handleNewClient(socket);
 
                     }).listen(parseInt(port), function() {
                         logger.debug(logSystem, logComponent, logSubCat, 'Switching "' + switchName
@@ -303,5 +297,35 @@ module.exports = function(logger){
             }
         });
         return foundCoin;
+    };
+
+    //
+    // Called when stratum pool emits its 'started' event to copy the initial diff and vardiff 
+    // configuation for any proxy switching ports configured into the stratum pool object.
+    //
+    this.setDifficultyForProxyPort = function(pool, coin, algo) {
+
+        logger.debug(logSystem, logComponent, algo, 'Setting proxy difficulties after pool start');
+
+        Object.keys(portalConfig.switching).forEach(function(switchName) {
+            if (!portalConfig.switching[switchName].enabled) return;
+
+            var switchAlgo = portalConfig.switching[switchName].algorithm;
+            if (pool.options.coin.algorithm !== switchAlgo) return;
+
+            // we know the switch configuration matches the pool's algo, so setup the diff and 
+            // vardiff for each of the switch's ports
+            for (var port in portalConfig.switching[switchName].ports) {
+
+                if (portalConfig.switching[switchName].ports[port].varDiff)
+                    pool.setVarDiff(port, portalConfig.switching[switchName].ports[port].varDiff);
+
+                if (portalConfig.switching[switchName].ports[port].diff){
+                    if (!pool.options.ports.hasOwnProperty(port)) 
+                        pool.options.ports[port] = {};
+                    pool.options.ports[port].diff = portalConfig.switching[switchName].ports[port].diff;
+                }
+            }
+        });
     };
 };


### PR DESCRIPTION
Please review and merge.  The fix is the same one I've been running on http://mintypool.com for a few weeks now, but applied to the NOMP profitswitch code.  It also ensures the starting diff for the proxy ports for all algos is as configured in the switching config.
