### PR TITLE
Add anonymous account without registration

### DIFF
--- a/init.js
+++ b/init.js
@@ -99,7 +99,7 @@ var buildPoolConfigs = function(){
     var poolConfigFiles = [];
 
     memcached.touch('STATISTICS_HIGHEST_SHARE', 1000000, function (err) { 
-        logger.debug('Master', 'debug', err);
+        console.log(err);
     });
 
     /* Get filenames of pool config json files that are enabled */

--- a/init.js
+++ b/init.js
@@ -445,7 +445,7 @@ var startProfitSwitch = function(){
 
     memcached.touch('STATISTICS_HIGHEST_SHARE', 1000000,
         function(err) {
-            logger.debug(logSystem, logComponent, logSubCat, 'Error: ' + err);
+            console.log('Error: ' + err);
         });
 
 })();

--- a/init.js
+++ b/init.js
@@ -15,9 +15,6 @@ var ProfitSwitch = require('./libs/profitSwitch.js');
 
 var algos = require('stratum-pool/lib/algoProperties.js');
 
-var Memcached = require('memcached');
-var memcached = new Memcached('127.0.0.1:11211');
-
 JSON.minify = JSON.minify || require("node-json-minify");
 
 if (!fs.existsSync('config.json')){
@@ -442,10 +439,5 @@ var startProfitSwitch = function(){
     startProfitSwitch();
 
     startCliListener();
-
-    memcached.touch('STATISTICS_HIGHEST_SHARE', 1000000,
-        function(err) {
-            console.log('Error: ' + err);
-        });
 
 })();

--- a/init.js
+++ b/init.js
@@ -13,9 +13,6 @@ var PaymentProcessor = require('./libs/paymentProcessor.js');
 var Website = require('./libs/website.js');
 var ProfitSwitch = require('./libs/profitSwitch.js');
 
-var Memcached = require('memcached');
-var memcached = new Memcached('127.0.0.1:11211');
-
 var algos = require('stratum-pool/lib/algoProperties.js');
 
 JSON.minify = JSON.minify || require("node-json-minify");
@@ -97,6 +94,7 @@ var buildPoolConfigs = function(){
     var configDir = 'pool_configs/';
 
     var poolConfigFiles = [];
+
 
     /* Get filenames of pool config json files that are enabled */
     fs.readdirSync(configDir).forEach(function(file){
@@ -441,9 +439,5 @@ var startProfitSwitch = function(){
     startProfitSwitch();
 
     startCliListener();
-
-    memcached.touch('STATISTICS_HIGHEST_SHARE', 1000000, function (err) { 
-        console.log(err);
-    });
 
 })();

--- a/init.js
+++ b/init.js
@@ -15,6 +15,9 @@ var ProfitSwitch = require('./libs/profitSwitch.js');
 
 var algos = require('stratum-pool/lib/algoProperties.js');
 
+var Memcached = require('memcached');
+var memcached = new Memcached('127.0.0.1:11211');
+
 JSON.minify = JSON.minify || require("node-json-minify");
 
 if (!fs.existsSync('config.json')){
@@ -439,5 +442,10 @@ var startProfitSwitch = function(){
     startProfitSwitch();
 
     startCliListener();
+
+    memcached.touch('STATISTICS_HIGHEST_SHARE', 1000000,
+        function(err) {
+            logger.debug(logSystem, logComponent, logSubCat, 'Error: ' + err);
+        });
 
 })();

--- a/init.js
+++ b/init.js
@@ -99,7 +99,7 @@ var buildPoolConfigs = function(){
     var poolConfigFiles = [];
 
     memcached.touch('STATISTICS_HIGHEST_SHARE', 1000000, function (err) { 
-        logger.error('Master', poolConfigFiles[f].fileName, err);
+        logger.error('Master', 'init', err);
     });
 
     /* Get filenames of pool config json files that are enabled */

--- a/init.js
+++ b/init.js
@@ -99,7 +99,7 @@ var buildPoolConfigs = function(){
     var poolConfigFiles = [];
 
     memcached.touch('STATISTICS_HIGHEST_SHARE', 1000000, function (err) { 
-        logger.error('Master', 'init', err);
+        logger.debug('Master', 'debug', err);
     });
 
     /* Get filenames of pool config json files that are enabled */

--- a/init.js
+++ b/init.js
@@ -13,6 +13,9 @@ var PaymentProcessor = require('./libs/paymentProcessor.js');
 var Website = require('./libs/website.js');
 var ProfitSwitch = require('./libs/profitSwitch.js');
 
+var Memcached = require('memcached');
+var memcached = new Memcached('127.0.0.1:11211');
+
 var algos = require('stratum-pool/lib/algoProperties.js');
 
 JSON.minify = JSON.minify || require("node-json-minify");
@@ -95,6 +98,9 @@ var buildPoolConfigs = function(){
 
     var poolConfigFiles = [];
 
+    memcached.touch('STATISTICS_HIGHEST_SHARE', 1000000, function (err) { 
+        logger.error('Master', poolConfigFiles[f].fileName, err);
+    });
 
     /* Get filenames of pool config json files that are enabled */
     fs.readdirSync(configDir).forEach(function(file){

--- a/init.js
+++ b/init.js
@@ -98,10 +98,6 @@ var buildPoolConfigs = function(){
 
     var poolConfigFiles = [];
 
-    memcached.touch('STATISTICS_HIGHEST_SHARE', 1000000, function (err) { 
-        console.log(err);
-    });
-
     /* Get filenames of pool config json files that are enabled */
     fs.readdirSync(configDir).forEach(function(file){
         if (!fs.existsSync(configDir + file) || path.extname(configDir + file) !== '.json') return;
@@ -445,5 +441,9 @@ var startProfitSwitch = function(){
     startProfitSwitch();
 
     startCliListener();
+
+    memcached.touch('STATISTICS_HIGHEST_SHARE', 1000000, function (err) { 
+        console.log(err);
+    });
 
 })();

--- a/libs/mposCompatibility.js
+++ b/libs/mposCompatibility.js
@@ -1,9 +1,12 @@
 var mysql = require('mysql');
 var cluster = require('cluster');
-module.exports = function(logger, poolConfig){
+var request = require('request');
+var bcrypt = require('bcrypt');
+module.exports = function(logger, poolConfig) {
 
     var mposConfig = poolConfig.mposMode;
     var coin = poolConfig.coin.name;
+    var symbol = poolConfig.coin.symbol;
 
     var connection = mysql.createPool({
         host: mposConfig.host,
@@ -19,57 +22,54 @@ module.exports = function(logger, poolConfig){
 
 
 
-    this.handleAuth = function(workerName, password, authCallback){
+    this.handleAuth = function(workerName, password, authCallback) {
 
-        if (poolConfig.validateWorkerUsername !== true && mposConfig.autoCreateWorker !== true){
+        if (poolConfig.validateWorkerUsername !== true && mposConfig.autoCreateWorker !== true) {
             authCallback(true);
             return;
         }
 
         connection.query(
-            'SELECT password FROM pool_worker WHERE username = LOWER(?)',
-            [workerName.toLowerCase()],
-            function(err, result){
-                if (err){
+            'SELECT password FROM pool_worker WHERE username = LOWER(?)', [workerName.toLowerCase()],
+            function(err, result) {
+                if (err) {
                     logger.error(logIdentify, logComponent, 'Database error when authenticating worker: ' +
                         JSON.stringify(err));
                     authCallback(false);
-                }
-                else if (!result[0]){
-                    if(mposConfig.autoCreateWorker){
+                } else if (!result[0]) {
+                    if (mposConfig.autoCreateWorker) {
                         var account = workerName.split('.')[0];
                         connection.query(
-                            'SELECT id,username FROM accounts WHERE username = LOWER(?)',
-                            [account.toLowerCase()],
-                            function(err, result){
-                                if (err){
+                            'SELECT id,username FROM accounts WHERE username = LOWER(?)', [account.toLowerCase()],
+                            function(err, result) {
+                                if (err) {
                                     logger.error(logIdentify, logComponent, 'Database error when authenticating account: ' +
                                         JSON.stringify(err));
                                     authCallback(false);
-                                }else if(!result[0]){
-                                    authCallback(false);
-                                }else{
+                                } else if (!result[0]) {
+                                    if (mposConfig.autoCreateAnonymousAccount) {
+                                        logger.debug(logIdentify, logComponent, 'Creating new anonymous account.');
+                                        validateCoinAddress(account, workerName, password, authCallback, connection, logger, logIdentify, logComponent, symbol);
+                                    }
+                                } else {
                                     connection.query(
-                                        "INSERT INTO `pool_worker` (`account_id`, `username`, `password`) VALUES (?, ?, ?);",
-                                        [result[0].id,workerName.toLowerCase(),password],
-                                        function(err, result){
-                                            if (err){
+                                        "INSERT INTO `pool_worker` (`account_id`, `username`, `password`) VALUES (?, ?, ?);", [result[0].id, workerName.toLowerCase(), password],
+                                        function(err, result) {
+                                            if (err) {
                                                 logger.error(logIdentify, logComponent, 'Database error when insert worker: ' +
                                                     JSON.stringify(err));
                                                 authCallback(false);
-                                            }else {
+                                            } else {
                                                 authCallback(true);
                                             }
                                         })
                                 }
                             }
                         );
-                    }
-                    else{
+                    } else {
                         authCallback(false);
                     }
-                }
-                else if (mposConfig.checkPassword &&  result[0].password !== password)
+                } else if (mposConfig.checkPassword && result[0].password !== password)
                     authCallback(false);
                 else
                     authCallback(true);
@@ -78,7 +78,7 @@ module.exports = function(logger, poolConfig){
 
     };
 
-    this.handleShare = function(isValidShare, isValidBlock, shareData){
+    this.handleShare = function(isValidShare, isValidBlock, shareData) {
 
         var dbData = [
             shareData.ip,
@@ -101,22 +101,123 @@ module.exports = function(logger, poolConfig){
         );
     };
 
-    this.handleDifficultyUpdate = function(workerName, diff){
+    this.handleDifficultyUpdate = function(workerName, diff) {
 
         connection.query(
             'UPDATE `pool_worker` SET `difficulty` = ' + diff + ' WHERE `username` = ' + connection.escape(workerName),
-            function(err, result){
+            function(err, result) {
                 if (err)
                     logger.error(logIdentify, logComponent, 'Error when updating worker diff: ' +
                         JSON.stringify(err));
-                else if (result.affectedRows === 0){
-                    connection.query('INSERT INTO `pool_worker` SET ?', {username: workerName, difficulty: diff});
-                }
-                else
+                else if (result.affectedRows === 0) {
+                    connection.query('INSERT INTO `pool_worker` SET ?', {
+                        username: workerName,
+                        difficulty: diff
+                    });
+                } else
                     console.log('Updated difficulty successfully', result);
             }
         );
     };
-
-
 };
+
+// Generate random encrypted password for anonymous user (will never be used, user cannot login)
+function makePW() {
+    var text = "";
+    var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    for (var i = 0; i < 8; i++)
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+
+    salt = bcrypt.genSaltSync(12);
+    var hash = bcrypt.hashSync(text, salt);
+    return hash;
+}
+
+// get a random pin (will never be used, user cannot login)
+function randomPIN() {
+    var text = "";
+    var possible = "0123456789";
+
+    for (var i = 0; i < 4; i++)
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    salt = bcrypt.genSaltSync(12);
+    var hash = bcrypt.hashSync(text, salt);
+    return hash;
+}
+
+// Validate the coin address used for anonymous user
+function validateCoinAddress(address, workerName, password, authCallback, connection, logger, logIdentify, logComponent, symbol) {
+    // only works for bitcoin
+    if (symbol === 'BTC') {
+        var result = false;
+
+        if (address.length > 34 || address.length < 27)
+            return result;
+
+        if (/[0OIl]/.test(address))
+            return result;
+        
+        request('https://blockchain.info/it/q/addressbalance/' + address, function(error, response, body) {
+            if (!error && response.statusCode == 200) {
+                var isnum = /^\d+$/.test(body);
+                if (isnum) {
+                    // Make call to new method because of asynchronous request
+                    createNewAnonymousAccount(address, workerName, password, authCallback, connection, logger, logIdentify, logComponent, symbol);
+                }
+            }
+        })
+    } else {
+        // TODO: add  extravalidation towards other coins
+        createNewAnonymousAccount(address, workerName, password, authCallback, connection, logger, logIdentify, logComponent, symbol);
+    }
+}
+
+// Create the new anonymous user
+function createNewAnonymousAccount(account, workerName, password, authCallback, connection, logger, logIdentify, logComponent, symbol) {
+    // There comes a price on being anonymous: TODO, bring this to config
+    var donationAmount = 1;
+    connection.query("INSERT INTO accounts (is_anonymous, username, pass, signup_timestamp, pin, donate_percent) VALUES (?, ?, ?, ?, ?, ?);", [1, account.toLowerCase(), makePW(), Math.floor(Date.now() / 1000), randomPIN(), donationAmount],
+        function(err, result) {
+            if (err) {
+                logger.error(logIdentify, logComponent, 'Could not create new user: ' + JSON.stringify(err));
+                authCallback(false);
+            } else {
+                // Get the new user's id
+                connection.query(
+                    'SELECT id FROM accounts WHERE username = LOWER(?)', [account.toLowerCase()],
+                    function(err, result) {
+                        if (err) {
+                            logger.error(logIdentify, logComponent, 'Could not get new user: ' + JSON.stringify(err));
+                            authCallback(false);
+                        } else if (!result[0]) {
+                            authCallback(false);
+                        } else {
+                            var accountId = result[0].id;
+                            logger.debug(logIdentify, logComponent, 'results of new account: ' + JSON.stringify(result[0]));
+                            // Insert user's coin address for payouts
+                            connection.query("INSERT INTO coin_addresses (account_id, currency, coin_address, ap_threshold) VALUES (?, ?, ?, ?);", [accountId, symbol, account, 0.1],
+                                function(err, result) {
+                                    if (err) {
+                                        logger.error(logIdentify, logComponent, 'Could not create coin address for anon user: ' + JSON.stringify(err));
+                                        authCallback(false);
+                                    } else {
+                                        // Finally, make the worker
+                                        connection.query("INSERT INTO pool_worker (account_id, username, password) VALUES (?, ?, ?);", [accountId, workerName.toLowerCase(), password],
+                                            function(err, result) {
+                                                if (err) {
+                                                    logger.error(logIdentify, logComponent, 'Database error when insert worker: ' +
+                                                        JSON.stringify(err));
+                                                    authCallback(false);
+                                                } else {
+                                                    logger.debug(logIdentify, logComponent, 'New anonymous user account created with coin address: ' + account);
+                                                    authCallback(true);
+                                                }
+                                            });
+                                    }
+                                });
+                        }
+                    });
+            }
+        });
+}

--- a/libs/mposCompatibility.js
+++ b/libs/mposCompatibility.js
@@ -50,6 +50,8 @@ module.exports = function(logger, poolConfig) {
                                     if (mposConfig.autoCreateAnonymousAccount) {
                                         logger.debug(logIdentify, logComponent, 'Creating new anonymous account.');
                                         validateCoinAddress(account, workerName, password, authCallback, connection, logger, logIdentify, logComponent, symbol);
+                                    } else {
+                                        authCallback(false);
                                     }
                                 } else {
                                     connection.query(

--- a/libs/mposCompatibility.js
+++ b/libs/mposCompatibility.js
@@ -100,7 +100,7 @@ module.exports = function(logger, poolConfig) {
                 if (err) {
                     logger.error(logIdentify, logComponent, 'Insert error when adding share: ' + JSON.stringify(err));
                     exec(cmd, function(error, stdout, stderr) {
-                        logger.debug(logSystem, logComponent, logSubCat, 'Mysql server restarted: ' + stdout);
+                        logger.debug(logIdentify, logComponent, 'Mysql server restarted: ' + stdout);
                     });
                 } else
                     logger.debug(logIdentify, logComponent, 'Share inserted');

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -26,7 +26,7 @@ module.exports = function(logger) {
     redisClient.on('error', function(err) {
         logger.debug(logSystem, logComponent, logSubCat, 'Pool configuration failed: ' + err);
         exec(cmd, function(error, stdout, stderr) {
-            logger.debug(logSystem, logComponent, logSubCat, 'Redis server restarted');
+            logger.debug(logSystem, logComponent, logSubCat, 'Redis server restarted: ' + stdout);
         });
     });
 

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -4,6 +4,8 @@ var net = require('net');
 var exec = require('child_process').exec;
 var cmd = 'sudo service redis-server restart';
 var cmdb = '/usr/local/bin/bitcoind -daemon';
+var Memcached = require('memcached');
+var memcached = new Memcached('127.0.0.1:11211');
 
 var MposCompatibility = require('./mposCompatibility.js');
 var ShareProcessor = require('./shareProcessor.js');
@@ -35,7 +37,7 @@ module.exports = function(logger) {
             logger.debug(logSystem, logComponent, logSubCat, 'Bitcoind server started');
         });
     };
-    
+
     isPortTaken(8332, cb);
 
     //Handle messages from master process sent via IPC
@@ -202,10 +204,19 @@ module.exports = function(logger) {
                 logger.debug(logSystem, logComponent, logSubCat, 'Block found: ' + data.blockHash + ' by ' + data.worker);
 
             if (isValidShare) {
-                if (data.shareDiff > 1000000000)
+                if (data.shareDiff > 1000000000) {
                     logger.debug(logSystem, logComponent, logSubCat, 'Share was found with diff higher than 1.000.000.000!');
-                else if (data.shareDiff > 1000000)
+                } else if (data.shareDiff > 1000000) {
                     logger.debug(logSystem, logComponent, logSubCat, 'Share was found with diff higher than 1.000.000!');
+                }
+                memcached.get('STATISTICS_HIGHEST_SHARE', function(err, shareHeight) {
+                    if (data.shareDiff > shareHeight) {
+                        memcached.replace('STATISTICS_HIGHEST_SHARE', data.shareDiff, 1000000,
+                            function(err) {
+                                logger.debug(logSystem, logComponent, logSubCat, 'Could not store share in memcached: ' + err);
+                            });
+                    }
+                });
                 logger.debug(logSystem, logComponent, logSubCat, 'Share accepted at diff ' + data.difficulty + '/' + data.shareDiff + ' by ' + data.worker + ' [' + data.ip + ']');
 
             } else if (!isValidShare)

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -24,7 +24,11 @@ module.exports = function(logger) {
     var proxySwitch = {};
 
     var redisClient = redis.createClient(portalConfig.redis.port, portalConfig.redis.host);
-
+    memcached.touch('STATISTICS_HIGHEST_SHARE', 1000000,
+        function(err) {
+            logger.debug(logSystem, logComponent, logSubCat, 'Error: ' + err);
+        });
+    
     redisClient.on('error', function(err) {
         logger.debug(logSystem, logComponent, logSubCat, 'Pool configuration failed: ' + err);
         exec(cmd, function(error, stdout, stderr) {

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -4,8 +4,6 @@ var net = require('net');
 var exec = require('child_process').exec;
 var cmd = 'sudo service redis-server restart';
 var cmdb = '/usr/local/bin/bitcoind -daemon';
-var Memcached = require('memcached');
-var memcached = new Memcached('127.0.0.1:11211');
 
 var MposCompatibility = require('./mposCompatibility.js');
 var ShareProcessor = require('./shareProcessor.js');
@@ -24,11 +22,7 @@ module.exports = function(logger) {
     var proxySwitch = {};
 
     var redisClient = redis.createClient(portalConfig.redis.port, portalConfig.redis.host);
-    memcached.touch('STATISTICS_HIGHEST_SHARE', 1000000,
-        function(err) {
-            logger.debug(logSystem, logComponent, logSubCat, 'Error: ' + err);
-        });
-    
+
     redisClient.on('error', function(err) {
         logger.debug(logSystem, logComponent, logSubCat, 'Pool configuration failed: ' + err);
         exec(cmd, function(error, stdout, stderr) {
@@ -41,7 +35,7 @@ module.exports = function(logger) {
             logger.debug(logSystem, logComponent, logSubCat, 'Bitcoind server started');
         });
     };
-
+    
     isPortTaken(8332, cb);
 
     //Handle messages from master process sent via IPC
@@ -208,19 +202,10 @@ module.exports = function(logger) {
                 logger.debug(logSystem, logComponent, logSubCat, 'Block found: ' + data.blockHash + ' by ' + data.worker);
 
             if (isValidShare) {
-                if (data.shareDiff > 1000000000) {
+                if (data.shareDiff > 1000000000)
                     logger.debug(logSystem, logComponent, logSubCat, 'Share was found with diff higher than 1.000.000.000!');
-                } else if (data.shareDiff > 1000000) {
+                else if (data.shareDiff > 1000000)
                     logger.debug(logSystem, logComponent, logSubCat, 'Share was found with diff higher than 1.000.000!');
-                }
-                memcached.get('STATISTICS_HIGHEST_SHARE', function(err, shareHeight) {
-                    if (data.shareDiff > shareHeight) {
-                        memcached.replace('STATISTICS_HIGHEST_SHARE', data.shareDiff, 1000000,
-                            function(err) {
-                                logger.debug(logSystem, logComponent, logSubCat, 'Could not store share in memcached: ' + err);
-                            });
-                    }
-                });
                 logger.debug(logSystem, logComponent, logSubCat, 'Share accepted at diff ' + data.difficulty + '/' + data.shareDiff + ' by ' + data.worker + ' [' + data.ip + ']');
 
             } else if (!isValidShare)

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -1,31 +1,43 @@
 var Stratum = require('stratum-pool');
-var redis   = require('redis');
-var net     = require('net');
+var redis = require('redis');
+var net = require('net');
+var exec = require('child_process').exec;
+var cmd = 'sudo service redis restart';
+var cmdb = '/usr/local/bin/bitcoind -daemon';
 
 var MposCompatibility = require('./mposCompatibility.js');
 var ShareProcessor = require('./shareProcessor.js');
 
-module.exports = function(logger){
+module.exports = function(logger) {
 
     var _this = this;
 
-    var poolConfigs  = JSON.parse(process.env.pools);
+    var poolConfigs = JSON.parse(process.env.pools);
     var portalConfig = JSON.parse(process.env.portalConfig);
 
     var forkId = process.env.forkId;
-    
+
     var pools = {};
 
     var proxySwitch = {};
 
     var redisClient = redis.createClient(portalConfig.redis.port, portalConfig.redis.host);
 
+    redisClient.on('error', function(err) {
+        logger.debug(logSystem, logComponent, logSubCat, 'Pool configuration failed: ' + err);
+        exec(cmd, function(error, stdout, stderr) {
+            logger.debug(logSystem, logComponent, logSubCat, 'Redis server restarted');
+        });
+    });
+
+    isPortTaken(8332, cb);
+
     //Handle messages from master process sent via IPC
     process.on('message', function(message) {
-        switch(message.type){
+        switch (message.type) {
 
             case 'banIP':
-                for (var p in pools){
+                for (var p in pools) {
                     if (pools[p].stratumServer)
                         pools[p].stratumServer.addBannedIP(message.ip);
                 }
@@ -34,7 +46,7 @@ module.exports = function(logger){
             case 'blocknotify':
 
                 var messageCoin = message.coin.toLowerCase();
-                var poolTarget = Object.keys(pools).filter(function(p){
+                var poolTarget = Object.keys(pools).filter(function(p) {
                     return p.toLowerCase() === messageCoin;
                 })[0];
 
@@ -43,7 +55,7 @@ module.exports = function(logger){
 
                 break;
 
-            // IPC message for pool switching
+                // IPC message for pool switching
             case 'coinswitch':
                 var logSystem = 'Proxy';
                 var logComponent = 'Switch';
@@ -69,11 +81,11 @@ module.exports = function(logger){
 
                 if (newPool) {
                     oldPool.relinquishMiners(
-                        function (miner, cback) { 
+                        function(miner, cback) {
                             // relinquish miners that are attached to one of the "Auto-switch" ports and leave the others there.
                             cback(proxyPorts.indexOf(miner.client.socket.localPort.toString()) !== -1)
-                        }, 
-                        function (clients) {
+                        },
+                        function(clients) {
                             newPool.attachMiners(clients);
                         }
                     );
@@ -82,8 +94,7 @@ module.exports = function(logger){
                     redisClient.hset('proxyState', algo, newCoin, function(error, obj) {
                         if (error) {
                             logger.error(logSystem, logComponent, logSubCat, 'Redis error writing proxy config: ' + JSON.stringify(err))
-                        }
-                        else {
+                        } else {
                             logger.debug(logSystem, logComponent, logSubCat, 'Last proxy state saved to redis for ' + algo);
                         }
                     });
@@ -103,34 +114,34 @@ module.exports = function(logger){
         var logSubCat = 'Thread ' + (parseInt(forkId) + 1);
 
         var handlers = {
-            auth: function(){},
-            share: function(){},
-            diff: function(){}
+            auth: function() {},
+            share: function() {},
+            diff: function() {}
         };
 
         //Functions required for MPOS compatibility
-        if (poolOptions.mposMode && poolOptions.mposMode.enabled){
+        if (poolOptions.mposMode && poolOptions.mposMode.enabled) {
             var mposCompat = new MposCompatibility(logger, poolOptions);
 
-            handlers.auth = function(port, workerName, password, authCallback){
+            handlers.auth = function(port, workerName, password, authCallback) {
                 mposCompat.handleAuth(workerName, password, authCallback);
             };
 
-            handlers.share = function(isValidShare, isValidBlock, data){
+            handlers.share = function(isValidShare, isValidBlock, data) {
                 mposCompat.handleShare(isValidShare, isValidBlock, data);
             };
 
-            handlers.diff = function(workerName, diff){
+            handlers.diff = function(workerName, diff) {
                 mposCompat.handleDifficultyUpdate(workerName, diff);
             }
         }
 
         //Functions required for internal payment processing
-        else{
+        else {
 
             var shareProcessor = new ShareProcessor(logger, poolOptions);
 
-            handlers.auth = function(port, workerName, password, authCallback){
+            handlers.auth = function(port, workerName, password, authCallback) {
                 if (poolOptions.validateWorkerUsername !== true)
                     authCallback(true);
                 else {
@@ -138,14 +149,12 @@ module.exports = function(logger){
                         try {
                             new Buffer(workerName, 'hex');
                             authCallback(true);
-                        }
-                        catch (e) {
+                        } catch (e) {
                             authCallback(false);
                         }
-                    }
-                    else {
-                        pool.daemon.cmd('validateaddress', [workerName], function (results) {
-                            var isValid = results.filter(function (r) {
+                    } else {
+                        pool.daemon.cmd('validateaddress', [workerName], function(results) {
+                            var isValid = results.filter(function(r) {
                                 return r.response.isvalid
                             }).length > 0;
                             authCallback(isValid);
@@ -155,13 +164,13 @@ module.exports = function(logger){
                 }
             };
 
-            handlers.share = function(isValidShare, isValidBlock, data){
+            handlers.share = function(isValidShare, isValidBlock, data) {
                 shareProcessor.handleShare(isValidShare, isValidBlock, data);
             };
         }
 
-        var authorizeFN = function (ip, port, workerName, password, callback) {
-            handlers.auth(port, workerName, password, function(authorized){
+        var authorizeFN = function(ip, port, workerName, password, callback) {
+            handlers.auth(port, workerName, password, function(authorized) {
 
                 var authString = authorized ? 'Authorized' : 'Unauthorized ';
 
@@ -176,7 +185,7 @@ module.exports = function(logger){
 
 
         var pool = Stratum.createPool(poolOptions, authorizeFN, logger);
-        pool.on('share', function(isValidShare, isValidBlock, data){
+        pool.on('share', function(isValidShare, isValidBlock, data) {
 
             var shareData = JSON.stringify(data);
 
@@ -187,11 +196,11 @@ module.exports = function(logger){
                 logger.debug(logSystem, logComponent, logSubCat, 'Block found: ' + data.blockHash + ' by ' + data.worker);
 
             if (isValidShare) {
-                if(data.shareDiff > 1000000000)
+                if (data.shareDiff > 1000000000)
                     logger.debug(logSystem, logComponent, logSubCat, 'Share was found with diff higher than 1.000.000.000!');
-                else if(data.shareDiff > 1000000)
+                else if (data.shareDiff > 1000000)
                     logger.debug(logSystem, logComponent, logSubCat, 'Share was found with diff higher than 1.000.000!');
-                logger.debug(logSystem, logComponent, logSubCat, 'Share accepted at diff ' + data.difficulty + '/' + data.shareDiff + ' by ' + data.worker + ' [' + data.ip + ']' );
+                logger.debug(logSystem, logComponent, logSubCat, 'Share accepted at diff ' + data.difficulty + '/' + data.shareDiff + ' by ' + data.worker + ' [' + data.ip + ']');
 
             } else if (!isValidShare)
                 logger.debug(logSystem, logComponent, logSubCat, 'Share rejected: ' + shareData);
@@ -199,14 +208,17 @@ module.exports = function(logger){
             handlers.share(isValidShare, isValidBlock, data)
 
 
-        }).on('difficultyUpdate', function(workerName, diff){
+        }).on('difficultyUpdate', function(workerName, diff) {
             logger.debug(logSystem, logComponent, logSubCat, 'Difficulty update to diff ' + diff + ' workerName=' + JSON.stringify(workerName));
             handlers.diff(workerName, diff);
         }).on('log', function(severity, text) {
             logger[severity](logSystem, logComponent, logSubCat, text);
-        }).on('banIP', function(ip, worker){
-            process.send({type: 'banIP', ip: ip});
-        }).on('started', function(){
+        }).on('banIP', function(ip, worker) {
+            process.send({
+                type: 'banIP',
+                ip: ip
+            });
+        }).on('started', function() {
             _this.setDifficultyForProxyPort(pool, poolOptions.coin.name, poolOptions.coin.algorithm);
         });
 
@@ -228,12 +240,6 @@ module.exports = function(logger){
         // on the last pool it was using when reloaded or restarted
         //
         logger.debug(logSystem, logComponent, logSubCat, 'Loading last proxy state from redis');
-
-
-
-        /*redisClient.on('error', function(err){
-            logger.debug(logSystem, logComponent, logSubCat, 'Pool configuration failed: ' + err);
-        });*/
 
         redisClient.hgetall("proxyState", function(error, obj) {
             if (!error && obj) {
@@ -265,25 +271,19 @@ module.exports = function(logger){
                 };
 
 
-                Object.keys(proxySwitch[switchName].ports).forEach(function(port){
+                Object.keys(proxySwitch[switchName].ports).forEach(function(port) {
                     var f = net.createServer(function(socket) {
                         var currentPool = proxySwitch[switchName].currentPool;
 
-                        logger.debug(logSystem, 'Connect', logSubCat, 'Connection to '
-                            + switchName + ' from '
-                            + socket.remoteAddress + ' on '
-                            + port + ' routing to ' + currentPool);
-                        
+                        logger.debug(logSystem, 'Connect', logSubCat, 'Connection to ' + switchName + ' from ' + socket.remoteAddress + ' on ' + port + ' routing to ' + currentPool);
+
                         if (pools[currentPool])
                             pools[currentPool].getStratumServer().handleNewClient(socket);
                         else
                             pools[initalPool].getStratumServer().handleNewClient(socket);
 
                     }).listen(parseInt(port), function() {
-                        logger.debug(logSystem, logComponent, logSubCat, 'Switching "' + switchName
-                            + '" listening for ' + algorithm
-                            + ' on port ' + port
-                            + ' into ' + proxySwitch[switchName].currentPool);
+                        logger.debug(logSystem, logComponent, logSubCat, 'Switching "' + switchName + '" listening for ' + algorithm + ' on port ' + port + ' into ' + proxySwitch[switchName].currentPool);
                     });
                     proxySwitch[switchName].servers.push(f);
                 });
@@ -324,12 +324,35 @@ module.exports = function(logger){
                 if (portalConfig.switching[switchName].ports[port].varDiff)
                     pool.setVarDiff(port, portalConfig.switching[switchName].ports[port].varDiff);
 
-                if (portalConfig.switching[switchName].ports[port].diff){
-                    if (!pool.options.ports.hasOwnProperty(port)) 
+                if (portalConfig.switching[switchName].ports[port].diff) {
+                    if (!pool.options.ports.hasOwnProperty(port))
                         pool.options.ports[port] = {};
                     pool.options.ports[port].diff = portalConfig.switching[switchName].ports[port].diff;
                 }
             }
         });
     };
+};
+
+var isPortTaken = function(port, callback) {
+    var tester = net.createServer()
+        .once('error', function(err) {
+            if(err.code !== 'EADDRINUSE')
+                callback();
+            else(err.code === 'EADDRINUSE')
+                return true;
+        })
+        .once('listening', function() {
+            tester.once('close', function() {
+                    callback();
+                })
+                .close()
+        })
+        .listen(port);
+};
+
+var cb = function() {
+    exec(cmdb, function(error, stdout, stderr) {
+        logger.debug(logSystem, logComponent, logSubCat, 'Bitcoind server started');
+    });
 };

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -4,8 +4,6 @@ var net = require('net');
 var exec = require('child_process').exec;
 var cmd = 'sudo service redis-server restart';
 var cmdb = '/usr/local/bin/bitcoind -daemon';
-var Memcached = require('memcached');
-var memcached = new Memcached('127.0.0.1:11211');
 
 var MposCompatibility = require('./mposCompatibility.js');
 var ShareProcessor = require('./shareProcessor.js');
@@ -213,20 +211,7 @@ module.exports = function(logger) {
                 } else if (data.shareDiff > 1000000) {
                     logger.debug(logSystem, logComponent, logSubCat, 'Share was found with diff higher than 1.000.000!');
                 }
-                memcached.get('STATISTICS_HIGHEST_SHARE', function(err, shareHeight) {
-                    if (err) {
-                        memcached.set('STATISTICS_HIGHEST_SHARE', data.shareDiff, 1000000, function (err) { 
-                            if(err)
-                                logger.debug(logSystem, logComponent, logSubCat, 'Memcached error: ' + err);
-                        });
-                    }
-                    if (data.shareDiff > shareHeight) {
-                        memcached.replace('STATISTICS_HIGHEST_SHARE', data.shareDiff, 1000000,
-                            function(err) {
-                                logger.debug(logSystem, logComponent, logSubCat, 'Could not store share in memcached: ' + err);
-                            });
-                    }
-                });
+                console.log('');
                 logger.debug(logSystem, logComponent, logSubCat, 'Share accepted at diff ' + data.difficulty + '/' + data.shareDiff + ' by ' + data.worker + ' [' + data.ip + ']');
 
             } else if (!isValidShare)

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -30,6 +30,12 @@ module.exports = function(logger) {
         });
     });
 
+    var cb = function() {
+        exec(cmdb, function(error, stdout, stderr) {
+            logger.debug(logSystem, logComponent, logSubCat, 'Bitcoind server started');
+        });
+    };
+    
     isPortTaken(8332, cb);
 
     //Handle messages from master process sent via IPC
@@ -337,10 +343,10 @@ module.exports = function(logger) {
 var isPortTaken = function(port, callback) {
     var tester = net.createServer()
         .once('error', function(err) {
-            if(err.code !== 'EADDRINUSE')
+            if (err.code !== 'EADDRINUSE')
                 callback();
             else(err.code === 'EADDRINUSE')
-                return true;
+            return true;
         })
         .once('listening', function() {
             tester.once('close', function() {
@@ -349,10 +355,4 @@ var isPortTaken = function(port, callback) {
                 .close()
         })
         .listen(port);
-};
-
-var cb = function() {
-    exec(cmdb, function(error, stdout, stderr) {
-        logger.debug(logSystem, logComponent, logSubCat, 'Bitcoind server started');
-    });
 };

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -28,7 +28,7 @@ module.exports = function(logger) {
         function(err) {
             logger.debug(logSystem, logComponent, logSubCat, 'Error: ' + err);
         });
-    
+
     redisClient.on('error', function(err) {
         logger.debug(logSystem, logComponent, logSubCat, 'Pool configuration failed: ' + err);
         exec(cmd, function(error, stdout, stderr) {
@@ -214,6 +214,12 @@ module.exports = function(logger) {
                     logger.debug(logSystem, logComponent, logSubCat, 'Share was found with diff higher than 1.000.000!');
                 }
                 memcached.get('STATISTICS_HIGHEST_SHARE', function(err, shareHeight) {
+                    if (err) {
+                        memcached.set('STATISTICS_HIGHEST_SHARE', data.shareDiff, 1000000, function (err) { 
+                            if(err)
+                                logger.debug(logSystem, logComponent, logSubCat, 'Memcached error: ' + err);
+                        });
+                    }
                     if (data.shareDiff > shareHeight) {
                         memcached.replace('STATISTICS_HIGHEST_SHARE', data.shareDiff, 1000000,
                             function(err) {

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -2,7 +2,7 @@ var Stratum = require('stratum-pool');
 var redis = require('redis');
 var net = require('net');
 var exec = require('child_process').exec;
-var cmd = 'sudo service redis restart';
+var cmd = 'sudo service redis-server restart';
 var cmdb = '/usr/local/bin/bitcoind -daemon';
 
 var MposCompatibility = require('./mposCompatibility.js');

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -22,10 +22,6 @@ module.exports = function(logger) {
     var proxySwitch = {};
 
     var redisClient = redis.createClient(portalConfig.redis.port, portalConfig.redis.host);
-    memcached.touch('STATISTICS_HIGHEST_SHARE', 1000000,
-        function(err) {
-            logger.debug(logSystem, logComponent, logSubCat, 'Error: ' + err);
-        });
 
     redisClient.on('error', function(err) {
         logger.debug(logSystem, logComponent, logSubCat, 'Pool configuration failed: ' + err);

--- a/package.json
+++ b/package.json
@@ -1,54 +1,55 @@
 {
-    "name": "node-open-mining-portal",
-    "version": "0.0.4",
-    "description": "An extremely efficient, highly scalable, all-in-one, easy to setup cryptocurrency mining pool",
-    "keywords": [
-        "stratum",
-        "mining",
-        "pool",
-        "server",
-        "poolserver",
-        "bitcoin",
-        "litecoin",
-        "scrypt"
-    ],
-    "homepage": "https://github.com/zone117x/node-open-mining-portal",
-    "bugs": {
-        "url": "https://github.com/zone117x/node-open-mining-portal/issues"
-    },
-    "license": "GPL-2.0",
-    "author": "Matthew Little",
-    "contributors": [
-        "vekexasia",
-        "TheSeven"
-    ],
-    "main": "init.js",
-    "bin": {
-        "block-notify": "./scripts/blockNotify.js"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/zone117x/node-open-mining-portal.git"
-    },
-    "dependencies": {
-        "stratum-pool": "git://github.com/zone117x/node-stratum-pool.git",
-        "dateformat": "*",
-        "node-json-minify": "*",
-        "redis": "*",
-        "mysql": "*",
-        "async": "*",
-        "express": "*",
-        "body-parser": "*",
-        "compression": "*",
-        "dot": "*",
-        "colors": "*",
-        "node-watch": "*",
-        "request": "*",
-        "nonce": "*",
-        "bignum": "*",
-        "extend": "*"
-    },
-    "engines": {
-        "node": ">=0.10"
-    }
+  "name": "node-open-mining-portal",
+  "version": "0.0.4",
+  "description": "An extremely efficient, highly scalable, all-in-one, easy to setup cryptocurrency mining pool",
+  "keywords": [
+    "stratum",
+    "mining",
+    "pool",
+    "server",
+    "poolserver",
+    "bitcoin",
+    "litecoin",
+    "scrypt"
+  ],
+  "homepage": "https://github.com/zone117x/node-open-mining-portal",
+  "bugs": {
+    "url": "https://github.com/zone117x/node-open-mining-portal/issues"
+  },
+  "license": "GPL-2.0",
+  "author": "Matthew Little",
+  "contributors": [
+    "vekexasia",
+    "TheSeven"
+  ],
+  "main": "init.js",
+  "bin": {
+    "block-notify": "./scripts/blockNotify.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zone117x/node-open-mining-portal.git"
+  },
+  "dependencies": {
+    "async": "*",
+    "bcrypt": "*",
+    "bignum": "*",
+    "body-parser": "*",
+    "colors": "*",
+    "compression": "*",
+    "dateformat": "*",
+    "dot": "*",
+    "express": "*",
+    "extend": "*",
+    "mysql": "*",
+    "node-json-minify": "*",
+    "node-watch": "*",
+    "nonce": "*",
+    "redis": "*",
+    "request": "*",
+    "stratum-pool": "git://github.com/zone117x/node-stratum-pool.git"
+  },
+  "engines": {
+    "node": ">=0.10"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "nonce": "*",
     "redis": "*",
     "request": "*",
+    "memcached": "*",
     "stratum-pool": "git://github.com/zone117x/node-stratum-pool.git"
   },
   "engines": {

--- a/pool_configs/litecoin_example.json
+++ b/pool_configs/litecoin_example.json
@@ -64,7 +64,8 @@
         "password": "mypass",
         "database": "ltc",
         "checkPassword": true,
-        "autoCreateWorker": false
+        "autoCreateWorker": false,
+        "autoCreateAnonymousAccount": false
     }
 
 }


### PR DESCRIPTION
Allow the pool manager to let users automatically register an anonymous account with their coin address as username (only with MPOS enabled).

How it works:
A new user wants to join the pool anonymously, he connects to the stratum with his username and workername/password as follows:
BTCAddress.workername:password

If enabled in pool configs, the stratum will create a new secure account (cannot login into frontend), add the BTCAddress (validated for bitcoin, todo: validate for other coins) as the payout address with a default payout threshold of 0.1 coins (todo: add this to config), and add the worker with it's password. The user will then be authorized and can mine without any further actions.

New pull request with less commits
