### PR TITLE
Update config_example.json

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -40,7 +40,7 @@
             "hashrateWindow": 300
         },
         "adminCenter": {
-            "enabled": true,
+            "enabled": false,
             "password": "password"
         }
     },


### PR DESCRIPTION
Because of the default static password we should disable the admin center to protect installations with the default configuration.