### PR TITLE
[Bug]: fixxed validateaddress, it is not working on newer nodes (0.16 +)

### DIFF
--- a/coins/globaltoken.json
+++ b/coins/globaltoken.json
@@ -1,0 +1,7 @@
+{
+    "name": "GlobalToken",
+    "symbol": "GLT",
+    "algorithm": "sha256",
+    "peerMagic": "c708d32d",
+    "peerMagicTestnet": "3a6f375b"
+}

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -70,6 +70,17 @@ function SetupForPool(logger, poolOptions, setupFinished){
                     callback(true);
                 }
                 else if (!result.response || !result.response.ismine) {
+                        daemon.cmd('getaddressinfo', [poolOptions.address], function(result) {
+                    if (result.error){
+                        logger.error(logSystem, logComponent, 'Error with payment processing daemon ' + JSON.stringify(result.error));
+                        callback(true);
+                    }
+                    else if (!result.response || !result.response.ismine) {
+                        logger.error(logSystem, logComponent,
+                                'Daemon does not own pool address - payment processing can not be done with this daemon, '
+                                + JSON.stringify(result.response));
+                        callback(true);
+                    }
                     logger.error(logSystem, logComponent,
                             'Daemon does not own pool address - payment processing can not be done with this daemon, '
                             + JSON.stringify(result.response));

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -70,21 +70,24 @@ function SetupForPool(logger, poolOptions, setupFinished){
                     callback(true);
                 }
                 else if (!result.response || !result.response.ismine) {
-                        daemon.cmd('getaddressinfo', [poolOptions.address], function(result) {
-                    if (result.error){
-                        logger.error(logSystem, logComponent, 'Error with payment processing daemon ' + JSON.stringify(result.error));
-                        callback(true);
-                    }
-                    else if (!result.response || !result.response.ismine) {
-                        logger.error(logSystem, logComponent,
-                                'Daemon does not own pool address - payment processing can not be done with this daemon, '
-                                + JSON.stringify(result.response));
-                        callback(true);
-                    }
                     logger.error(logSystem, logComponent,
-                            'Daemon does not own pool address - payment processing can not be done with this daemon, '
+                            'Validateaddress failed, trying for newer getaddressinfo Command ..., '
                             + JSON.stringify(result.response));
-                    callback(true);
+                            daemon.cmd('getaddressinfo', [poolOptions.address], function(result) {
+                        if (result.error){
+                            logger.error(logSystem, logComponent, 'Error with payment processing daemon, getaddressinfo failed ... ' + JSON.stringify(result.error));
+                            callback(true);
+                        }
+                        else if (!result.response || !result.response.ismine) {
+                            logger.error(logSystem, logComponent,
+                                    'Daemon does not own pool address - payment processing can not be done with this daemon, '
+                                    + JSON.stringify(result.response));
+                            callback(true);
+                        }
+                        else{
+                            callback()
+                        }
+                    }, true);
                 }
                 else{
                     callback()

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -70,9 +70,6 @@ function SetupForPool(logger, poolOptions, setupFinished){
                     callback(true);
                 }
                 else if (!result.response || !result.response.ismine) {
-                    logger.error(logSystem, logComponent,
-                            'Validateaddress failed, trying for newer getaddressinfo Command ..., '
-                            + JSON.stringify(result.response));
                             daemon.cmd('getaddressinfo', [poolOptions.address], function(result) {
                         if (result.error){
                             logger.error(logSystem, logComponent, 'Error with payment processing daemon, getaddressinfo failed ... ' + JSON.stringify(result.error));


### PR DESCRIPTION
With this Pull request I fix a Bug, that occur, when you are trying to setup a Pool that has the newer RPC Command 'getaddressinfo'.

The 'validateaddress' info is not longer providing the 'ismine' response, so you need to change it to 'getaddressinfo'.

I also thought about old wallet compatibility, it will first check the 'validateaddress' command (old nodes like Altcoin Nodes mostly just support validateaddress) and if validateaddress is not providing ismine, it will auto check for getaddressinfo.

Regards,

Globaltoken Dev.