### PR TITLE
[MPOS] pass share difficulty to MySQL

### DIFF
--- a/libs/mposCompatibility.js
+++ b/libs/mposCompatibility.js
@@ -85,7 +85,7 @@ module.exports = function(logger, poolConfig){
             shareData.worker,
             isValidShare ? 'Y' : 'N',
             isValidBlock ? 'Y' : 'N',
-            shareData.difficulty * (poolConfig.coin.mposDiffMultiplier || 1),
+            shareData.shareDiff * (poolConfig.coin.mposDiffMultiplier || 1),
             typeof(shareData.error) === 'undefined' ? null : shareData.error,
             shareData.blockHash ? shareData.blockHash : (shareData.blockHashInvalid ? shareData.blockHashInvalid : '')
         ];


### PR DESCRIPTION
Miners should be paid by actual shares, this requires the share diff to be known to the payment processor. Worker diff isn't correct here.