### PR TITLE
introduce poolOptions for legacy, p2sh and bech32 keys

### DIFF
--- a/coins/00_example.json
+++ b/coins/00_example.json
@@ -1,0 +1,25 @@
+{
+    "name": "Example",
+    "symbol": "EXM",
+    "algorithm": "x99",
+    "peerMagic": "0f0f0f0f",
+    "peerMagicTestnet": "f0f0f0f0",
+
+    "mainnet": {
+      "bech32": "ex",
+      "bip32": {
+        "public": "0f0f0f0f"
+      },
+      "pubKeyHash": "00",
+      "scriptHash": "ff"
+    },
+
+    "testnet": {
+      "bech32": "tex",
+      "bip32": {
+        "public": "f0f0f0f0"
+      },
+      "pubKeyHash": "0f",
+      "scriptHash": "f0"
+    }
+}

--- a/coins/chaincoin.json
+++ b/coins/chaincoin.json
@@ -1,0 +1,7 @@
+{
+    "name": "Chaincoin",
+    "symbol": "CHC",
+    "algorithm": "c11",
+    "peerMagic": "a3d27a03",
+    "peerMagicTestnet": "fbc21102"
+}

--- a/coins/chaincoin.json
+++ b/coins/chaincoin.json
@@ -3,5 +3,23 @@
     "symbol": "CHC",
     "algorithm": "c11",
     "peerMagic": "a3d27a03",
-    "peerMagicTestnet": "fbc21102"
+    "peerMagicTestnet": "fbc21102",
+
+    "mainnet": {
+      "bech32": "chc",
+      "bip32": {
+        "public": "0488b21e"
+      },
+      "pubKeyHash": "1c",
+      "scriptHash": "04"
+    },
+
+    "testnet": {
+      "bech32": "tchc",
+      "bip32": {
+        "public": "043587cf"
+      },
+      "pubKeyHash": "50",
+      "scriptHash": "2c"
+    }
 }

--- a/init.js
+++ b/init.js
@@ -147,6 +147,17 @@ var buildPoolConfigs = function(){
         var coinProfile = JSON.parse(JSON.minify(fs.readFileSync(coinFilePath, {encoding: 'utf8'})));
         poolOptions.coin = coinProfile;
         poolOptions.coin.name = poolOptions.coin.name.toLowerCase();
+        if (coinProfile.mainnet) {
+            poolOptions.coin.mainnet.bip32.public = Buffer.from(coinProfile.mainnet.bip32.public, 'hex').readUInt32LE(0);
+            poolOptions.coin.mainnet.pubKeyHash = Buffer.from(coinProfile.mainnet.pubKeyHash, 'hex').readUInt8(0);
+            poolOptions.coin.mainnet.scriptHash = Buffer.from(coinProfile.mainnet.scriptHash, 'hex').readUInt8(0);
+        }
+        if (coinProfile.testnet) {
+            poolOptions.coin.testnet.bip32.public = Buffer.from(coinProfile.testnet.bip32.public, 'hex').readUInt32LE(0);
+            poolOptions.coin.testnet.pubKeyHash = Buffer.from(coinProfile.testnet.pubKeyHash, 'hex').readUInt8(0);
+            poolOptions.coin.testnet.scriptHash = Buffer.from(coinProfile.testnet.scriptHash, 'hex').readUInt8(0);
+        }
+
 
         if (poolOptions.coin.name in configs){
 

--- a/libs/mposCompatibility.js
+++ b/libs/mposCompatibility.js
@@ -85,7 +85,7 @@ module.exports = function(logger, poolConfig){
             shareData.worker,
             isValidShare ? 'Y' : 'N',
             isValidBlock ? 'Y' : 'N',
-            shareData.difficulty * (poolConfig.coin.mposDiffMultiplier || 1),
+            shareData.shareDiff,
             typeof(shareData.error) === 'undefined' ? null : shareData.error,
             shareData.blockHash ? shareData.blockHash : (shareData.blockHashInvalid ? shareData.blockHashInvalid : '')
         ];

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -4,7 +4,6 @@ var net     = require('net');
 
 var MposCompatibility = require('./mposCompatibility.js');
 var ShareProcessor = require('./shareProcessor.js');
-var Stratum = require('stratum-pool');
 
 module.exports = function(logger){
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "url": "https://github.com/zone117x/node-open-mining-portal.git"
     },
     "dependencies": {
-        "stratum-pool": "git://github.com/zone117x/node-stratum-pool.git",
+        "stratum-pool": "git://github.com/zone117x/node-stratum-pool.git -b dev",
         "dateformat": "1.0.12",
         "node-json-minify": "*",
         "redis": "0.12.1",


### PR DESCRIPTION
This PR is extending the capabilities of coin.json by adding network info (option). Examples are included. When starting up, those parameters are initialised and can be used by submodules.
We are also switching the dependencies to the dev branch of node-stratum-pool where those parameters are used later on.