### PR TITLE
 Allow pool owner to run the pool without explicitly declare the address

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "node-watch": "*",
         "request": "2.69.0",
         "nonce": "*",
-        "bignum": "0.12.5",
+        "bignum": "0.13.0",
         "extend": "*"
     },
     "engines": {


### PR DESCRIPTION
- Setting the address to false (pool_configs > coin.json), will generate a new address on startup and after every submission of block