### PR TITLE
Fix node-watch warning

### DIFF
--- a/libs/website.js
+++ b/libs/website.js
@@ -95,7 +95,7 @@ module.exports = function(logger){
 
 
     //If an html file was changed reload it
-    watch('website', function(filename){
+    watch('website', function(evt, filename){
         var basename = path.basename(filename);
         if (basename in pageFiles){
             console.log(filename);


### PR DESCRIPTION
zone117x/node-open-mining-portal#649

(node:4020) DeprecationWarning: (node-watch) First param in callback function is replaced with event name since 0.5.0, use (evt, filename) => {} if you want to get the filename
