### PR TITLE
Marscoin and mooncoin added

### DIFF
--- a/coins/marscoin.json
+++ b/coins/marscoin.json
@@ -1,0 +1,7 @@
+{
+    
+    "name": "Marscoin",
+    "symbol": "MARS",
+    "algorithm": "scrypt"
+    
+}

--- a/coins/mooncoin.json
+++ b/coins/mooncoin.json
@@ -1,0 +1,7 @@
+{
+    
+    "name": "Mooncoin",
+    "symbol": "MOON",
+    "algorithm": "scrypt"
+    
+}


### PR DESCRIPTION
Marscoin ( MARS ) from marscoin.org and Mooncoin ( MOON ) from mooncoin.com and mooncoinofficial.com