### PR TITLE
Change git:// to https://

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "url": "https://github.com/zone117x/node-open-mining-portal.git"
     },
     "dependencies": {
-        "stratum-pool": "git://github.com/zone117x/node-stratum-pool.git",
+        "stratum-pool": "https://github.com/zone117x/node-stratum-pool.git",
         "dateformat": "1.0.12",
         "node-json-minify": "*",
         "redis": "0.12.1",


### PR DESCRIPTION
npm cannot access dependencies if you use git://. You must change it to https::/